### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,9 +124,9 @@ def train(epoch):
                 else:
                     consistent_loss = consistent_loss + consistent_criterion(logp_fast,p_tch)
                 
-        consistent_loss = consistent_loss*alpha/args.num_fast 
+            meta_loss = consistent_loss*alpha/args.num_fast 
             
-        consistent_loss.backward()
+            meta_loss.backward()
                 
         optimizer.step() # Optimizer update
 


### PR DESCRIPTION
From the original paper

[Learning to Learn from Noisy Labeled Data](https://arxiv.org/abs/1812.05214)

The algorithm states that the meta loss should be calculated after every consistency loss is accumulated:

![image](https://user-images.githubusercontent.com/22272655/90301418-4f1cb000-ded2-11ea-8159-4e0597f070fe.png)

While in the original code, the consistency loss does not accumulate before divide the number of mini-batch

![image](https://user-images.githubusercontent.com/22272655/90301674-f1896300-ded3-11ea-8fca-0816da414dd2.png)

This issue was mentioned in #7 before, but if the consistency_loss gradient is accumulated across M synthetic data

Then it should not be divided by M( args.num_fast in the source) every time after generating noisy labels

This pull request should fix the problems that appear in  #8 and #9 as well.

The GPU memory usage problems should be resolved after decreasing the number in args.num_fast
